### PR TITLE
Add meta to Web Configuration for saving webpage as a standalone iOS web app

### DIFF
--- a/source/main/index.html
+++ b/source/main/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Tonex One">
     <title>Tonex One Controller Project</title>
     
   </head>


### PR DESCRIPTION
Added following head meta tags to Web Control:

- `apple-mobile-web-app-capable` - allows for saving webpage to iOS home screen as a standalone webapp (instead of opening it always in Safari)
- `apple-mobile-web-app-status-bar-style` - sets status bar color
- `apple-mobile-web-app-title` - changes default title to fit on iOS home screen

With those changes when you use Share in Safari and you "Add to Home Screen":

<img src="https://github.com/user-attachments/assets/7d361aef-5865-4c33-bb05-32e1b574380a" width="300">

then you get a web shortcut, that opens as a standalone app (instead of opening in your browser)

<img src="https://github.com/user-attachments/assets/0efaa17e-2862-42f4-a013-7ef43b755ed6" width="200">