### PR TITLE
Add display for bpm and fx status for 1.69 screens. Add CC#99 and CC#100 to set tempo

### DIFF
--- a/source/main/display.c
+++ b/source/main/display.c
@@ -1087,6 +1087,10 @@ void ParameterChanged(lv_event_t * e)
     {
         usb_modify_parameter(TONEX_GLOBAL_TEMPO_SOURCE, lv_obj_has_state(obj, LV_STATE_CHECKED) ? 1 : 0);
     }
+    else if (obj == ui_TuningReferenceSlider)
+    {
+        usb_modify_parameter(TONEX_GLOBAL_TUNING_REFERENCE, lv_slider_get_value(obj));
+    }
     else
     {
         ESP_LOGW(TAG, "Unknown Parameter changed");    
@@ -2669,6 +2673,12 @@ static uint8_t update_ui_element(tUIUpdate* update)
                         {
                             lv_slider_set_range(ui_InputTrimSlider, round(param_entry->Min), round(param_entry->Max));
                             lv_slider_set_value(ui_InputTrimSlider, round(param_entry->Value), LV_ANIM_OFF);                                
+                        } break;
+                        
+                        case TONEX_GLOBAL_TUNING_REFERENCE:
+                        {                            
+                            lv_slider_set_range(ui_TuningReferenceSlider, round(param_entry->Min), round(param_entry->Max));
+                            lv_slider_set_value(ui_TuningReferenceSlider, round(param_entry->Value), LV_ANIM_OFF);                                
                         } break;
                     } 
 

--- a/source/main/display.c
+++ b/source/main/display.c
@@ -1087,10 +1087,6 @@ void ParameterChanged(lv_event_t * e)
     {
         usb_modify_parameter(TONEX_GLOBAL_TEMPO_SOURCE, lv_obj_has_state(obj, LV_STATE_CHECKED) ? 1 : 0);
     }
-    else if (obj == ui_TuningReferenceSlider)
-    {
-        usb_modify_parameter(TONEX_GLOBAL_TUNING_REFERENCE, lv_slider_get_value(obj));
-    }
     else
     {
         ESP_LOGW(TAG, "Unknown Parameter changed");    
@@ -2674,18 +2670,97 @@ static uint8_t update_ui_element(tUIUpdate* update)
                             lv_slider_set_range(ui_InputTrimSlider, round(param_entry->Min), round(param_entry->Max));
                             lv_slider_set_value(ui_InputTrimSlider, round(param_entry->Value), LV_ANIM_OFF);                                
                         } break;
-
-                        case TONEX_GLOBAL_TUNING_REFERENCE:
-                        {                            
-                            lv_slider_set_range(ui_TuningReferenceSlider, round(param_entry->Min), round(param_entry->Max));
-                            lv_slider_set_value(ui_TuningReferenceSlider, round(param_entry->Value), LV_ANIM_OFF);                                
-                        } break;
                     } 
 
                     tonex_params_release_locked_access();
                 }               
             }
-#endif            
+#endif
+
+#if CONFIG_TONEX_CONTROLLER_HARDWARE_PLATFORM_WAVESHARE_169 || CONFIG_TONEX_CONTROLLER_HARDWARE_PLATFORM_WAVESHARE_169TOUCH
+
+
+
+
+            ESP_LOGI(TAG, "Syncing params to UI");
+
+            tTonexParameter* param_ptr;
+
+            for (uint16_t param = 0; param < TONEX_GLOBAL_LAST; param++)
+            {                     
+                if (tonex_params_get_locked_access(&param_ptr) == ESP_OK)
+                {
+                    tTonexParameter* param_entry = &param_ptr[param];
+
+                    // debug
+                    //ESP_LOGI(TAG, "Param %d: val: %02f, min: %02f, max: %02f", param, param_entry->Value, param_entry->Min, param_entry->Max);
+
+                    switch (param)
+                    {
+                        case TONEX_GLOBAL_BPM:
+                        {
+                            char buf[128];
+                            sprintf(buf, "%d", (int)round(param_entry->Value));
+                            lv_label_set_text(ui_BPM, buf);  
+                        } break;
+
+
+
+                        case TONEX_PARAM_COMP_ENABLE:
+                        {
+                            if (param_entry->Value)
+                            {
+                                lv_obj_set_style_border_color(ui_CStatus, lv_color_hex(0xDDDD00), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            }
+                            else
+                            {
+                                lv_obj_set_style_border_color(ui_CStatus, lv_color_hex(0x563F2A), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            }
+                        } break;
+                        case TONEX_PARAM_MODULATION_ENABLE:
+                        {
+                            if (param_entry->Value)
+                            {
+                                lv_obj_set_style_border_color(ui_MStatus, lv_color_hex(0xEEAA00), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            }
+                            else
+                            {
+                                lv_obj_set_style_border_color(ui_MStatus, lv_color_hex(0x563F2A), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            }
+                        } break;
+                        case TONEX_PARAM_DELAY_ENABLE:
+                        {
+                            if (param_entry->Value)
+                            {
+                                lv_obj_set_style_border_color(ui_DStatus, lv_color_hex(0x00CC00), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            }
+                            else
+                            {
+                                lv_obj_set_style_border_color(ui_DStatus, lv_color_hex(0x563F2A), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            }
+                        } break;
+
+                        case TONEX_PARAM_REVERB_ENABLE:
+                        {
+                            if (param_entry->Value)
+                            {
+                                lv_obj_set_style_border_color(ui_RStatus, lv_color_hex(0x33FFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            }
+                            else
+                            {
+                                lv_obj_set_style_border_color(ui_RStatus, lv_color_hex(0x563F2A), LV_PART_MAIN | LV_STATE_DEFAULT);
+                            }
+                        } break;
+
+                    }
+
+                    tonex_params_release_locked_access();
+                }               
+            }
+
+
+
+#endif
         } break;
 
         default:

--- a/source/main/midi_helper.c
+++ b/source/main/midi_helper.c
@@ -694,13 +694,14 @@ esp_err_t midi_helper_adjust_param_via_midi(uint8_t change_num, uint8_t midi_val
             return ESP_OK;
         } break;
 
+
         case 88: 
         {
             // bpm
             param = TONEX_GLOBAL_BPM;            
             value = midi_helper_scale_midi_to_float(param, midi_value);
         } break;
-
+        
         // 89: bank down
         // 90: bank up    
 
@@ -748,6 +749,20 @@ esp_err_t midi_helper_adjust_param_via_midi(uint8_t change_num, uint8_t midi_val
         } break;
 
         // 96 to 101 not used       
+
+        case 99: 
+        {
+            // bpm
+            param = TONEX_GLOBAL_BPM; 
+            value = (midi_value < 40) ? 40 : midi_value;
+        } break;
+        
+        case 100: 
+        {
+            // bpm
+            param = TONEX_GLOBAL_BPM;            
+            value = midi_value+100;
+        } break;
 
         case 102:
         {

--- a/source/main/ui_generated_169/screens/ui_Screen1.c
+++ b/source/main/ui_generated_169/screens/ui_Screen1.c
@@ -141,4 +141,83 @@ void ui_Screen1_screen_init(void)
     lv_img_set_zoom(ui_WiFiStatusConn, 220);
 
 
+    ui_BPMLabel = lv_label_create(ui_Screen1);
+    lv_obj_set_width(ui_BPMLabel, 80);
+    lv_obj_set_height(ui_BPMLabel, 50);
+    lv_obj_set_x(ui_BPMLabel, 6);
+    lv_obj_set_y(ui_BPMLabel, -55);
+    lv_obj_set_align(ui_BPMLabel, LV_ALIGN_RIGHT_MID);
+    lv_label_set_text(ui_BPMLabel, "BPM\n");
+    lv_obj_set_style_text_color(ui_BPMLabel, lv_color_hex(0xCCCCCC), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_opa(ui_BPMLabel, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_align(ui_BPMLabel, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_font(ui_BPMLabel, &lv_font_montserrat_20, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+    
+    ui_BPM = lv_label_create(ui_Screen1);
+    lv_obj_set_width(ui_BPM, 80);
+    lv_obj_set_height(ui_BPM, 50);
+    lv_obj_set_x(ui_BPM, 6);
+    lv_obj_set_y(ui_BPM, -35);
+    lv_obj_set_align(ui_BPM, LV_ALIGN_RIGHT_MID);
+    lv_label_set_text(ui_BPM, "?");
+    lv_obj_set_style_text_color(ui_BPM, lv_color_hex(0xCCCCCC), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_opa(ui_BPM, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_align(ui_BPM, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_font(ui_BPM, &lv_font_montserrat_30, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+
+    static lv_style_t FXstyle;
+    lv_style_init(&FXstyle);
+    lv_style_set_radius(&FXstyle, 5);
+    lv_style_set_bg_opa(&FXstyle, LV_OPA_COVER);
+    lv_style_set_bg_color(&FXstyle, lv_color_hex(0x1F1F1F));
+    lv_style_set_border_width(&FXstyle, 2);
+    lv_style_set_border_color(&FXstyle, lv_color_hex(0x563F2A));
+    lv_style_set_text_color(&FXstyle, lv_color_hex(0xFFFFFF));
+    lv_style_set_text_opa(&FXstyle, 255);
+    lv_style_set_text_align(&FXstyle, LV_TEXT_ALIGN_CENTER);
+    lv_style_set_text_font(&FXstyle, &lv_font_montserrat_20);
+    lv_style_set_radius(&FXstyle, 10);
+
+
+
+    ui_CStatus = lv_label_create(ui_Screen1);    
+    lv_obj_add_style(ui_CStatus, &FXstyle, 0);
+    lv_obj_set_width(ui_CStatus, 28);
+    lv_obj_set_height(ui_CStatus, 28);
+    lv_obj_set_x(ui_CStatus, -98);
+    lv_obj_set_y(ui_CStatus, -72);
+    lv_obj_set_align(ui_CStatus, LV_ALIGN_CENTER);
+    lv_label_set_text(ui_CStatus, "C");
+
+    ui_MStatus = lv_label_create(ui_Screen1);    
+    lv_obj_add_style(ui_MStatus, &FXstyle, 0);
+    lv_obj_set_width(ui_MStatus, 28);
+    lv_obj_set_height(ui_MStatus, 28);
+    lv_obj_set_x(ui_MStatus, -98);
+    lv_obj_set_y(ui_MStatus, -40);
+    lv_obj_set_align(ui_MStatus, LV_ALIGN_CENTER);
+    lv_label_set_text(ui_MStatus, "M");
+
+    
+    ui_DStatus = lv_label_create(ui_Screen1);    
+    lv_obj_add_style(ui_DStatus, &FXstyle, 0);
+    lv_obj_set_width(ui_DStatus, 28);
+    lv_obj_set_height(ui_DStatus, 28);
+    lv_obj_set_x(ui_DStatus, -65);
+    lv_obj_set_y(ui_DStatus, -72);
+    lv_obj_set_align(ui_DStatus, LV_ALIGN_CENTER);
+    lv_label_set_text(ui_DStatus, "D");
+
+    ui_RStatus = lv_label_create(ui_Screen1);    
+    lv_obj_add_style(ui_RStatus, &FXstyle, 0);
+    lv_obj_set_width(ui_RStatus, 28);
+    lv_obj_set_height(ui_RStatus, 28);
+    lv_obj_set_x(ui_RStatus, -65);
+    lv_obj_set_y(ui_RStatus, -40);
+    lv_obj_set_align(ui_RStatus, LV_ALIGN_CENTER);
+    lv_label_set_text(ui_RStatus, "R");
+
+
 }

--- a/source/main/ui_generated_169/ui.c
+++ b/source/main/ui_generated_169/ui.c
@@ -23,6 +23,14 @@ lv_obj_t * ui_BTStatusDisconn;
 lv_obj_t * ui_BTStatusConn;
 lv_obj_t * ui_WiFiStatusDisconn;
 lv_obj_t * ui_WiFiStatusConn;
+
+lv_obj_t * ui_BPMLabel;
+lv_obj_t * ui_BPM;
+
+lv_obj_t * ui_CStatus;
+lv_obj_t * ui_MStatus;
+lv_obj_t * ui_DStatus;
+lv_obj_t * ui_RStatus;
 // CUSTOM VARIABLES
 
 // EVENTS

--- a/source/main/ui_generated_169/ui.h
+++ b/source/main/ui_generated_169/ui.h
@@ -30,6 +30,14 @@ extern lv_obj_t * ui_BTStatusDisconn;
 extern lv_obj_t * ui_BTStatusConn;
 extern lv_obj_t * ui_WiFiStatusDisconn;
 extern lv_obj_t * ui_WiFiStatusConn;
+
+extern lv_obj_t * ui_BPMLabel;
+extern lv_obj_t * ui_BPM;
+
+extern lv_obj_t * ui_CStatus;
+extern lv_obj_t * ui_MStatus;
+extern lv_obj_t * ui_DStatus;
+extern lv_obj_t * ui_RStatus;
 // CUSTOM VARIABLES
 
 // EVENTS


### PR DESCRIPTION
Add display for bpm and fx status for 1.69 screens. 
Add CC#99 to set tempo to exact CC value above 40. Value 40 or below will set tempo to 40
Add CC#100 to set tempo 100 + CC Value. e.g. CC#100 value 60 will set tempo to 160, value 120 will set tempo to 220.