### PR TITLE
Add CC (#127) that does same thing as PC changes

### DIFF
--- a/source/main/midi_helper.c
+++ b/source/main/midi_helper.c
@@ -886,6 +886,19 @@ esp_err_t midi_helper_adjust_param_via_midi(uint8_t change_num, uint8_t midi_val
             value = tonex_params_clamp_value(param, value);
         } break;
 
+        case 127: 
+        {
+            // Custom case: use CC to change params.
+            if (midi_value > 19) {
+                ESP_LOGW(TAG, "Unsupported Midi CC 127 value %d", change_num);
+            } else {
+                control_request_preset_index(midi_value);
+            }
+
+            // no param change needed
+            return ESP_OK;
+        } break;
+
         default:
         {
             ESP_LOGW(TAG, "Unsupported Midi change number %d", change_num);
@@ -1462,6 +1475,12 @@ uint16_t midi_helper_get_param_for_change_num(uint8_t change_num)
          {
              param = TONEX_GLOBAL_TUNING_REFERENCE;
          } break;
+         case 127:
+         {
+            // Need the CC value to use this, so this won't work for
+            // footswitches, and it's kind of irrelevant anyways.
+            ESP_LOGW(TAG, "Unsupported Midi change number %d", change_num);
+         }
     }
 
     return param;


### PR DESCRIPTION
I added this as I wanted something to help deal with the 3 snapshot limit in my HX Stomp. I also noticed it's on your TODO list. So far, this does not support being done with footswitches, but seems irrelevant anyways. I picked CC 127 somewhat arbitrarily, feel free to change this to whatever you want. I have tested this on my Waveshare Zero and it works as intended.