### PR TITLE
footswitches: fix error shift count negative

### DIFF
--- a/source/main/footswitches.c
+++ b/source/main/footswitches.c
@@ -964,7 +964,12 @@ void footswitches_init(i2c_master_bus_handle_t bus_handle, SemaphoreHandle_t I2C
     // init GPIO
     gpio_config_t gpio_config_struct;
 
-    gpio_config_struct.pin_bit_mask = (((uint64_t)1 << FOOTSWITCH_1) | ((uint64_t)1 << FOOTSWITCH_2) | ((uint64_t)1 << FOOTSWITCH_3) | ((uint64_t)1 << FOOTSWITCH_4));
+    uint64_t pin_bit_mask = 0;
+    if (FOOTSWITCH_1 >= 0) pin_bit_mask |= ((uint64_t)1 << FOOTSWITCH_1);
+    if (FOOTSWITCH_2 >= 0) pin_bit_mask |= ((uint64_t)1 << FOOTSWITCH_2);
+    if (FOOTSWITCH_3 >= 0) pin_bit_mask |= ((uint64_t)1 << FOOTSWITCH_3);
+    if (FOOTSWITCH_4 >= 0) pin_bit_mask |= ((uint64_t)1 << FOOTSWITCH_4);
+    gpio_config_struct.pin_bit_mask = pin_bit_mask;
     gpio_config_struct.mode = GPIO_MODE_INPUT;
     gpio_config_struct.pull_up_en = GPIO_PULLUP_ENABLE;
     gpio_config_struct.pull_down_en = GPIO_PULLDOWN_DISABLE;


### PR DESCRIPTION
This fixes an error with the latest version of esp-idf If one of the footswitches is set to -1 the shift operation set the wrong bit.

Error:
```shell
/home/user/src/TonexOneController/source/main/footswitches.c: In function 'footswitches_init':
/home/user/src/TonexOneController/source/main/footswitches.c:967:117: error: left shift count is negative [-Werror=shift-count-negative]
967 | gpio_config_struct.pin_bit_mask = (((uint64_t)1 << FOOTSWITCH_1) | ((uint64_t)1 << FOOTSWITCH_2) | ((uint64_t)1 << FOOTSWITCH_3) | ((uint64_t)1 << FOOTSWITCH_4));
| ^~
/home/user/src/TonexOneController/source/main/footswitches.c:967:149: error: left shift count is negative [-Werror=shift-count-negative]
967 | gpio_config_struct.pin_bit_mask = (((uint64_t)1 << FOOTSWITCH_1) | ((uint64_t)1 << FOOTSWITCH_2) | ((uint64_t)1 << FOOTSWITCH_3) | ((uint64_t)1 << FOOTSWITCH_4));
|
```

