### PR TITLE
feat: AB slot bank up/down via MIDI CC 89/90

### DIFF
--- a/source/main/control.c
+++ b/source/main/control.c
@@ -73,6 +73,8 @@ enum CommandEvents
     EVENT_PRESET_UP,
     EVENT_PRESET_INDEX,
     EVENT_BANK_INDEX,
+    EVENT_AB_BANK_DOWN,
+    EVENT_AB_BANK_UP,
     EVENT_SET_PRESET_NAME,
     EVENT_SET_PRESET_DETAILS,
     EVENT_SET_USB_STATUS,
@@ -248,6 +250,7 @@ typedef struct
 typedef struct 
 {
     uint32_t PresetIndex;                        // 0-based index
+    uint8_t ABSlotBank;                          // 0-based AB slot bank (Slot A = bank*2, Slot B = bank*2+1)
     char PresetNames[MAX_SUPPORTED_PRESETS][MAX_PRESET_NAME_LENGTH];
     uint32_t USBStatus;
     uint32_t BTStatus;
@@ -349,6 +352,46 @@ static uint8_t process_control_command(tControlMessage* message)
 #endif
         } break;
 
+        case EVENT_AB_BANK_DOWN:
+        {
+            if (ControlData.USBStatus != 0)
+            {
+                uint8_t max_bank = (usb_get_max_presets_for_connected_modeller() / 2) - 1;
+
+                if (ControlData.ABSlotBank > 0)
+                {
+                    ControlData.ABSlotBank--;
+                }
+                else if (control_get_config_item_int(CONFIG_ITEM_LOOP_AROUND))
+                {
+                    ControlData.ABSlotBank = max_bank;
+                }
+
+                // load both slots, force A/B (Double) mode, activate Slot A and refresh display
+                usb_set_ab_slots(ControlData.ABSlotBank * 2, ControlData.ABSlotBank * 2 + 1);
+            }
+        } break;
+
+        case EVENT_AB_BANK_UP:
+        {
+            if (ControlData.USBStatus != 0)
+            {
+                uint8_t max_bank = (usb_get_max_presets_for_connected_modeller() / 2) - 1;
+
+                if (ControlData.ABSlotBank < max_bank)
+                {
+                    ControlData.ABSlotBank++;
+                }
+                else if (control_get_config_item_int(CONFIG_ITEM_LOOP_AROUND))
+                {
+                    ControlData.ABSlotBank = 0;
+                }
+
+                // load both slots, force A/B (Double) mode, activate Slot A and refresh display
+                usb_set_ab_slots(ControlData.ABSlotBank * 2, ControlData.ABSlotBank * 2 + 1);
+            }
+        } break;
+        
         case EVENT_SET_PRESET_NAME:
         {
             memcpy((void*)ControlData.PresetNames[message->Value], (void*)message->Text, MAX_PRESET_NAME_LENGTH);
@@ -1039,6 +1082,51 @@ void control_request_bank_index(uint8_t index)
     if (xQueueSend(control_input_queue, (void*)&message, pdMS_TO_TICKS(CONTROL_QUEUE_WRITE_TIMEOUT)) != pdPASS)
     {
         ESP_LOGE(TAG, "control_request_bank_index queue send failed!");            
+    }
+}
+
+
+/****************************************************************************
+* NAME:
+* DESCRIPTION:
+* PARAMETERS:
+* RETURN:
+* NOTES:
+*****************************************************************************/
+void control_request_ab_bank_down(void)
+{
+    tControlMessage message;
+
+    ESP_LOGI(TAG, "control_request_ab_bank_down");
+
+    message.Event = EVENT_AB_BANK_DOWN;
+
+    // send to queue
+    if (xQueueSend(control_input_queue, (void*)&message, pdMS_TO_TICKS(CONTROL_QUEUE_WRITE_TIMEOUT)) != pdPASS)
+    {
+        ESP_LOGE(TAG, "control_request_ab_bank_down queue send failed!");
+    }
+}
+
+/****************************************************************************
+* NAME:
+* DESCRIPTION:
+* PARAMETERS:
+* RETURN:
+* NOTES:
+*****************************************************************************/
+void control_request_ab_bank_up(void)
+{
+    tControlMessage message;
+
+    ESP_LOGI(TAG, "control_request_ab_bank_up");
+
+    message.Event = EVENT_AB_BANK_UP;
+
+    // send to queue
+    if (xQueueSend(control_input_queue, (void*)&message, pdMS_TO_TICKS(CONTROL_QUEUE_WRITE_TIMEOUT)) != pdPASS)
+    {
+        ESP_LOGE(TAG, "control_request_ab_bank_up queue send failed!");
     }
 }
 

--- a/source/main/control.h
+++ b/source/main/control.h
@@ -316,6 +316,8 @@ void control_request_preset_up(void);
 void control_request_preset_down(void);
 void control_request_preset_index(uint8_t index);
 void control_request_bank_index(uint8_t index);
+void control_request_ab_bank_up(void);
+void control_request_ab_bank_down(void);
 void control_set_usb_status(uint32_t status);
 void control_set_bt_status(uint32_t status);
 void control_set_wifi_status(uint32_t status);

--- a/source/main/midi_helper_tonex.c
+++ b/source/main/midi_helper_tonex.c
@@ -958,8 +958,21 @@ esp_err_t midi_helper_tonex_adjust_param_via_midi(uint8_t change_num, uint8_t mi
             value = midi_helper_scale_midi_to_float(param, midi_value);
         } break;
         
-        // 89: bank down
-        // 90: bank up    
+        case 89:
+        {
+            // A/B slot bank down
+            control_request_ab_bank_down();
+
+            return ESP_OK;
+        } break;
+        
+        case 90:
+        {
+            // A/B slot bank up
+            control_request_ab_bank_up();
+
+            return ESP_OK;
+        } break;
 
         case 91:
         {

--- a/source/main/usb_comms.c
+++ b/source/main/usb_comms.c
@@ -525,6 +525,34 @@ void usb_load_preset_to_slot_b(uint32_t preset)
 }
 
 /****************************************************************************
+* NAME:
+* DESCRIPTION:
+* PARAMETERS:
+* RETURN:
+* NOTES:
+*****************************************************************************/  
+void usb_set_ab_slots(uint32_t preset_a, uint32_t preset_b)
+{
+    tUSBMessage message;
+
+    if (usb_input_queue == NULL)
+    {
+        ESP_LOGE(TAG, "usb_set_ab_slots queue null");
+    }
+    else
+    {
+        message.Command = USB_COMMAND_SET_AB_SLOTS;
+        message.Payload = ((preset_a & 0xFF) << 8) | (preset_b & 0xFF);
+
+        // send to queue
+        if (xQueueSend(usb_input_queue, (void*)&message, 0) != pdPASS)
+        {
+            ESP_LOGE(TAG, "usb_set_ab_slots queue send failed!");
+        }
+    }
+}
+
+/****************************************************************************
 * NAME:        
 * DESCRIPTION: 
 * PARAMETERS:  

--- a/source/main/usb_comms.h
+++ b/source/main/usb_comms.h
@@ -46,7 +46,8 @@ enum USB_Commands
     USB_COMMAND_MODIFY_PARAMETER,
     USB_COMMAND_LOAD_PRESET_TO_SLOT_A,
     USB_COMMAND_LOAD_PRESET_TO_SLOT_B,
-    USB_COMMAND_SAVE_PRESET
+    USB_COMMAND_SAVE_PRESET,
+    USB_COMMAND_SET_AB_SLOTS
 };
 
 typedef struct 
@@ -71,6 +72,7 @@ void usb_set_preset(uint32_t preset);
 void usb_modify_parameter(uint16_t index, float value);
 void usb_load_preset_to_slot_a(uint32_t preset);
 void usb_load_preset_to_slot_b(uint32_t preset);
+void usb_set_ab_slots(uint32_t preset_a, uint32_t preset_b);
 void usb_save_preset(void);
 uint8_t usb_get_max_presets_for_connected_modeller(void);
 uint8_t usb_get_first_preset_index_for_connected_modeller(void);

--- a/source/main/usb_tonex_one.c
+++ b/source/main/usb_tonex_one.c
@@ -184,6 +184,7 @@ static volatile tInputBufferEntry* InputBuffers;
 static TonexStatus usb_tonex_one_parse(uint8_t* message, uint16_t inlength);
 static esp_err_t usb_tonex_one_set_active_slot(Slot newSlot);
 static esp_err_t usb_tonex_one_set_preset_in_slot(uint16_t preset, Slot newSlot, uint8_t selectSlot);
+static esp_err_t usb_tonex_one_set_ab_slots(uint16_t preset_a, uint16_t preset_b);
 static uint16_t usb_tonex_one_get_current_active_preset(void);
 
 
@@ -544,6 +545,62 @@ static esp_err_t usb_tonex_one_set_preset_in_slot(uint16_t preset, Slot newSlot,
 
     // send it
     return tonex_common_transmit(cdc_dev, FramedBuffer, framed_length, TONEX_USB_TX_BUFFER_SIZE);
+}
+
+/****************************************************************************
+* NAME:
+* DESCRIPTION:
+* PARAMETERS:
+* RETURN:
+* NOTES:
+*****************************************************************************/
+static esp_err_t usb_tonex_one_set_ab_slots(uint16_t preset_a, uint16_t preset_b)
+{
+    uint16_t framed_length;
+    uint16_t len = TonexData->Message.PedalData.StateDataLength;
+
+    ESP_LOGI(TAG, "Setting AB slots. A: %d B: %d (Double mode, Slot A active)", (int)preset_a, (int)preset_b);
+
+    // Build message, length to 0 for now                    len LSB  len MSB
+    uint8_t message[] = {0xb9, 0x03, 0x81, 0x06, 0x03, 0x82, 0,       0,       0x80, 0x0b, 0x03};
+
+    // set length
+    message[6] = len & 0xFF;
+    message[7] = (len >> 8) & 0xFF;
+
+    // force A/B (Double) mode (0 = A/B mode, 1 = stomp mode)
+    TonexData->Message.PedalData.StateData[TONEX_STATE_OFFSET_START_STOMP_MODE] = 0;
+
+    // make sure direct monitoring is on so sound not muted from USB connection
+    TonexData->Message.PedalData.StateData[len - TONEX_STATE_OFFSET_END_DIRECT_MONITOR] = 1;
+
+    // set both slot presets
+    TonexData->Message.PedalData.StateData[len - TONEX_STATE_OFFSET_END_SLOT_A_PRESET] = preset_a;
+    TonexData->Message.PedalData.StateData[len - TONEX_STATE_OFFSET_END_SLOT_B_PRESET] = preset_b;
+
+    // make Slot A the active slot
+    TonexData->Message.PedalData.StateData[len - TONEX_STATE_OFFSET_END_CURRENT_SLOT] = (uint8_t)A;
+    TonexData->Message.CurrentSlot = A;
+
+    // update cached slot presets so the active preset reports correctly
+    TonexData->Message.SlotAPreset = preset_a;
+    TonexData->Message.SlotBPreset = preset_b;
+
+    // build total message
+    memcpy((void*)TxBuffer, (void*)message, sizeof(message));
+    memcpy((void*)&TxBuffer[sizeof(message)], (void*)TonexData->Message.PedalData.StateData, len);
+
+    // do framing
+    framed_length = tonex_common_add_framing(TxBuffer, sizeof(message) + len, FramedBuffer);
+
+    // send it
+    if (tonex_common_transmit(cdc_dev, FramedBuffer, framed_length, TONEX_USB_TX_BUFFER_SIZE) != ESP_OK)
+    {
+        return ESP_FAIL;
+    }
+
+    // refresh the display to show Slot A's preset as active
+    return usb_tonex_one_request_preset_details(preset_a, 0);
 }
 
 /****************************************************************************
@@ -1362,6 +1419,25 @@ void usb_tonex_one_handle(class_driver_t* driver_obj)
                             ESP_LOGW(TAG, "Invalid preset index %d for Slot B (max %d)", (int)message.Payload, MAX_PRESETS_TONEX_ONE - 1);
                         }
                     } break;   
+                    
+                    case USB_COMMAND_SET_AB_SLOTS:
+                    {
+                        uint16_t preset_a = (message.Payload >> 8) & 0xFF;
+                        uint16_t preset_b = message.Payload & 0xFF;
+
+                        if ((preset_a < MAX_PRESETS_TONEX_ONE) && (preset_b < MAX_PRESETS_TONEX_ONE))
+                        {
+                            ESP_LOGI(TAG, "Set AB slots via MIDI. A: %d B: %d", (int)preset_a, (int)preset_b);
+                            if (usb_tonex_one_set_ab_slots(preset_a, preset_b) != ESP_OK)
+                            {
+                                ESP_LOGE(TAG, "Failed to set AB slots A:%d B:%d", (int)preset_a, (int)preset_b);
+                            }
+                        }
+                        else
+                        {
+                            ESP_LOGW(TAG, "Invalid AB slot presets A:%d B:%d (max %d)", (int)preset_a, (int)preset_b, MAX_PRESETS_TONEX_ONE - 1);
+                        }
+                    } break;
                     
                     case USB_COMMAND_MODIFY_PARAMETER:
                     {


### PR DESCRIPTION
Adds A/B slot bank up/down (MIDI CC 89/90), pre-loading two presets into Slot A/B for instant, low-latency A/B switching.

When banking up/down, Slot A preset is always activated by default. If loop is disabled in settings, cycling will not wrap around from the last bank back to the first bank.